### PR TITLE
feat: Canvas-based signup and sync UI

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,1 @@
-API_BASE="https://id-dev-api.bacchus.io"
+API_BASE="http://localhost:50080"

--- a/api/canvas.ts
+++ b/api/canvas.ts
@@ -1,0 +1,92 @@
+export type CanvasProfilePair = {
+  studentNumber: string;
+  major: string;
+};
+
+export type CanvasPreviewResult = {
+  name: string;
+  emails: string[];
+  profiles: CanvasProfilePair[];
+  matchedGroups: Array<{
+    groupIdx: number;
+    name: { ko: string; en: string };
+    reasonKey: 'student_id_cse' | 'course';
+    reasonDetail?: string;
+  }>;
+};
+
+export type CanvasDiff = {
+  profiles: { toAdd: CanvasProfilePair[]; existing: CanvasProfilePair[] };
+  emails: {
+    toAdd: Array<{ local: string; domain: string }>;
+    existing: Array<{ local: string; domain: string }>;
+  };
+  groups: {
+    items: Array<{
+      groupIdx: number;
+      groupName: { ko: string; en: string };
+      reasonKey: 'student_id_cse' | 'course';
+      reasonDetail?: string;
+      status: 'new' | 'pending' | 'member';
+    }>;
+  };
+};
+
+export type CanvasAction =
+  | { type: 'add_student_number'; studentNumber: string }
+  | { type: 'add_email'; emailLocal: string; emailDomain: string }
+  | { type: 'add_group'; groupIdx: number };
+
+export async function previewCanvas(canvasToken: string): Promise<CanvasPreviewResult> {
+  const resp = await fetch('/canvas/preview', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ canvasToken }),
+  });
+  if (!resp.ok) {
+    const body = await resp.json().catch(() => ({}));
+    throw new Error(body?.message ?? 'Canvas 토큰이 유효하지 않습니다.');
+  }
+  return resp.json();
+}
+
+export async function syncCanvas(canvasToken: string): Promise<CanvasDiff> {
+  const resp = await fetch('/canvas/sync', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ canvasToken }),
+    credentials: 'same-origin',
+  });
+  if (!resp.ok) {
+    const body = await resp.json().catch(() => ({}));
+    throw new Error(body?.message ?? 'Canvas 동기화 실패');
+  }
+  return resp.json();
+}
+
+export async function applyCanvas(actions: CanvasAction[]): Promise<void> {
+  const resp = await fetch('/canvas/apply', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ actions }),
+    credentials: 'same-origin',
+  });
+  if (!resp.ok) { throw new Error('적용 실패'); }
+}
+
+export async function canvasSignup(
+  canvasToken: string,
+  username: string,
+  password: string,
+  preferredLanguage: string,
+): Promise<void> {
+  const resp = await fetch('/signup/canvas', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ canvasToken, username, password, preferredLanguage }),
+  });
+  if (!resp.ok) {
+    const body = await resp.json().catch(() => ({}));
+    throw new Error(body?.message ?? '계정 생성 실패');
+  }
+}

--- a/api/index.ts
+++ b/api/index.ts
@@ -33,6 +33,7 @@ const listGroupsSchema = z.array(
     idx: z.number(),
     name: z.record(z.string()),
     description: z.record(z.string()),
+    identifier: z.string(),
     isPending: z.boolean(),
     isMember: z.boolean(),
     isDirectMember: z.boolean(),
@@ -47,6 +48,7 @@ export type Group = {
   joined: boolean;
   implied: boolean;
   owner: boolean;
+  identifier: string;
 };
 export async function listGroups(): Promise<Group[]> {
   const cookie = headers().get('cookie') || '';
@@ -71,6 +73,7 @@ export async function listGroups(): Promise<Group[]> {
     joined: value.isDirectMember,
     implied: value.isMember,
     owner: value.isOwner,
+    identifier: value.identifier,
   }));
 }
 

--- a/app/(nolocale)/canvas/apply/route.ts
+++ b/app/(nolocale)/canvas/apply/route.ts
@@ -1,0 +1,15 @@
+import { apiUrl } from '@/api';
+import { headers } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request): Promise<Response> {
+  const cookie = headers().get('cookie') || '';
+  const body = await request.json();
+  const resp = await fetch(apiUrl('/api/canvas/apply'), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify(body),
+  });
+  const data = await resp.json().catch(() => ({}));
+  return NextResponse.json(data, { status: resp.status });
+}

--- a/app/(nolocale)/canvas/preview/route.ts
+++ b/app/(nolocale)/canvas/preview/route.ts
@@ -1,0 +1,13 @@
+import { apiUrl } from '@/api';
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request): Promise<Response> {
+  const body = await request.json();
+  const resp = await fetch(apiUrl('/api/canvas/preview'), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = await resp.json().catch(() => ({}));
+  return NextResponse.json(data, { status: resp.status });
+}

--- a/app/(nolocale)/canvas/sync/route.ts
+++ b/app/(nolocale)/canvas/sync/route.ts
@@ -1,0 +1,15 @@
+import { apiUrl } from '@/api';
+import { headers } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request): Promise<Response> {
+  const cookie = headers().get('cookie') || '';
+  const body = await request.json();
+  const resp = await fetch(apiUrl('/api/canvas/sync'), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify(body),
+  });
+  const data = await resp.json().catch(() => ({}));
+  return NextResponse.json(data, { status: resp.status });
+}

--- a/app/(nolocale)/signup/canvas/route.ts
+++ b/app/(nolocale)/signup/canvas/route.ts
@@ -1,0 +1,13 @@
+import { apiUrl } from '@/api';
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request): Promise<Response> {
+  const body = await request.json();
+  const resp = await fetch(apiUrl('/api/user/canvas-signup'), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = await resp.json().catch(() => ({}));
+  return NextResponse.json(data, { status: resp.status });
+}

--- a/app/(nolocale)/user/email/route.ts
+++ b/app/(nolocale)/user/email/route.ts
@@ -1,0 +1,23 @@
+import { apiUrl } from '@/api';
+import { headers } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+export async function DELETE(request: Request): Promise<Response> {
+  const cookie = headers().get('cookie') || '';
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ message: 'Invalid body' }, { status: 400 });
+  }
+  const resp = await fetch(apiUrl('/api/user/email'), {
+    method: 'DELETE',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) {
+    const data = await resp.json().catch(() => ({}));
+    return NextResponse.json(data, { status: resp.status });
+  }
+  return new Response(null, { status: 200 });
+}

--- a/app/(nolocale)/user/student-numbers/route.ts
+++ b/app/(nolocale)/user/student-numbers/route.ts
@@ -1,7 +1,8 @@
+import { headers } from 'next/headers';
 import { NextResponse } from 'next/server';
 import * as z from 'zod';
 
-import { addStudentNumber, BadRequestError, DuplicateError, ForbiddenError } from '@/api';
+import { addStudentNumber, apiUrl, BadRequestError, DuplicateError, ForbiddenError } from '@/api';
 import { getDictionary, getLocaleFromCookie } from '@/locale';
 
 const bodySchema = z.object({
@@ -57,4 +58,24 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   return new Response(null, { status: 201 });
+}
+
+export async function DELETE(request: Request): Promise<Response> {
+  const cookie = headers().get('cookie') || '';
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ message: 'Invalid body' }, { status: 400 });
+  }
+  const resp = await fetch(apiUrl('/api/user/student-numbers'), {
+    method: 'DELETE',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) {
+    const data = await resp.json().catch(() => ({}));
+    return NextResponse.json(data, { status: resp.status });
+  }
+  return new Response(null, { status: 200 });
 }

--- a/app/[locale]/(authorized)/StudentIdForm.tsx
+++ b/app/[locale]/(authorized)/StudentIdForm.tsx
@@ -1,3 +1,4 @@
+/* === ARCHIVED: replaced by Canvas-based student ID management ===
 'use client';
 
 import { useState } from 'react';
@@ -136,6 +137,71 @@ export default function StudentIdForm({ studentNumbers }: { studentNumbers: stri
           {formDict.buttonAdd}
         </Button>
       </form>
+    </>
+  );
+}
+=== END ARCHIVED === */
+
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import Button from '@/components/Button';
+import useLocaleDict from '@/components/LocaleDict';
+import { useToast } from '@/components/NotificationContext';
+
+export default function StudentIdForm({ studentNumbers }: { studentNumbers: string[] }) {
+  const { dict } = useLocaleDict();
+  const d = dict.studentId;
+  const showToast = useToast();
+  const router = useRouter();
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  async function handleDelete(sn: string) {
+    setDeleting(sn);
+    try {
+      const resp = await fetch('/user/student-numbers', {
+        method: 'DELETE',
+        body: JSON.stringify({ studentNumber: sn }),
+        headers: { 'content-type': 'application/json' },
+      });
+      if (!resp.ok) {
+        showToast({ type: 'error', message: dict.error.unknown });
+        return;
+      }
+      showToast({ type: 'info', message: '학번이 삭제되었습니다.' });
+      router.refresh();
+    } catch {
+      showToast({ type: 'error', message: dict.error.unknown });
+    } finally {
+      setDeleting(null);
+    }
+  }
+
+  return (
+    <>
+      <p>{d.description}</p>
+      <p className="mt-2">{d.currentStudentId}</p>
+      {studentNumbers.length === 0 ? (
+        <p className="text-dimmed">-</p>
+      ) : (
+        <ul className="mt-1 space-y-1">
+          {[...studentNumbers].sort().map(sn => (
+            <li key={sn} className="flex items-center gap-2">
+              <span className="font-mono">{sn}</span>
+              <Button
+                color="accent"
+                className="text-xs px-2 py-0.5"
+                disabled={deleting === sn}
+                onClick={() => handleDelete(sn)}
+              >
+                {d.buttonDelete}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
     </>
   );
 }

--- a/app/[locale]/(authorized)/canvas/CanvasDiff.tsx
+++ b/app/[locale]/(authorized)/canvas/CanvasDiff.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import { useState } from 'react';
+import type { CanvasDiff, CanvasAction } from '@/api/canvas';
+import { applyCanvas } from '@/api/canvas';
+import Button from '@/components/Button';
+import useLocaleDict from '@/components/LocaleDict';
+import { useToast } from '@/components/NotificationContext';
+
+type Props = {
+  diff: CanvasDiff;
+  onApplied: () => void;
+};
+
+export default function CanvasDiffView({ diff, onApplied }: Props) {
+  const { dict } = useLocaleDict();
+  const d = dict.canvas;
+  const showToast = useToast();
+  const locale = (useParams().locale as string) || 'ko';
+
+  const selectableItems = [
+    ...(diff.profiles?.toAdd ?? []).map(p => `sn_${p.studentNumber}`),
+    ...diff.emails.toAdd.map(e => `em_${e.local}@${e.domain}`),
+    ...diff.groups.items.filter(g => g.status === 'new' || g.status === 'pending').map(g => `g_${g.groupIdx}`),
+  ];
+
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(selectableItems));
+  const [applying, setApplying] = useState(false);
+
+  function toggle(key: string) {
+    setSelected(prev => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+  }
+
+  async function handleApply() {
+    const actions: CanvasAction[] = [];
+    (diff.profiles?.toAdd ?? []).forEach(p => {
+      if (selected.has(`sn_${p.studentNumber}`)) actions.push({ type: 'add_student_number', studentNumber: p.studentNumber });
+    });
+    diff.emails.toAdd.forEach(e => {
+      if (selected.has(`em_${e.local}@${e.domain}`)) actions.push({ type: 'add_email', emailLocal: e.local, emailDomain: e.domain });
+    });
+    diff.groups.items.filter(g => g.status === 'new' || g.status === 'pending').forEach(g => {
+      if (selected.has(`g_${g.groupIdx}`)) actions.push({ type: 'add_group', groupIdx: g.groupIdx });
+    });
+    if (actions.length === 0) return;
+    setApplying(true);
+    try {
+      await applyCanvas(actions);
+      showToast({ type: 'info', message: d.applySuccess });
+      onApplied();
+    } catch {
+      showToast({ type: 'error', message: dict.error.unknown });
+    } finally {
+      setApplying(false);
+    }
+  }
+
+  const groupName = (g: CanvasDiff['groups']['items'][0]) =>
+    locale === 'ko' ? g.groupName.ko : g.groupName.en;
+
+  const groupReason = (g: CanvasDiff['groups']['items'][0]) =>
+    g.reasonKey === 'student_id_cse'
+      ? d.reasonStudentIdCse
+      : g.reasonDetail
+        ? d.reasonCourseWithTerm.replace('{}', g.reasonDetail)
+        : d.reasonCourse;
+
+  // 기존 항목 행 (체크 불가)
+  function ExistingRow({ label }: { label: string }) {
+    return (
+      <div className="flex items-center gap-2 py-1">
+        <input type="checkbox" checked disabled className="opacity-50" />
+        <span className="text-dimmed text-sm">{label}</span>
+      </div>
+    );
+  }
+
+  // 추가 가능 행 (체크 가능)
+  function AddRow({ id, label, tag }: { id: string; label: string; tag?: string }) {
+    return (
+      <label className="flex items-center gap-2 py-1 cursor-pointer">
+        <input type="checkbox" checked={selected.has(id)} onChange={() => toggle(id)} />
+        <span className="text-sm">
+          {label}
+          <span className="text-green-600 text-xs ml-1">[{d.actionAdd}]</span>
+          {tag && <span className="text-dimmed text-xs ml-1">({tag})</span>}
+        </span>
+      </label>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* 학번 · 주전공 */}
+      {((diff.profiles?.existing?.length ?? 0) > 0 || (diff.profiles?.toAdd?.length ?? 0) > 0) && (
+        <section>
+          <h3 className="text-h3 mb-1">{d.sectionStudentNumbers}</h3>
+          {(diff.profiles?.existing ?? []).map(p => (
+            <ExistingRow key={p.studentNumber} label={`${p.studentNumber}${p.major ? ` — ${p.major}` : ''}`} />
+          ))}
+          {(diff.profiles?.toAdd ?? []).map(p => (
+            <AddRow key={p.studentNumber} id={`sn_${p.studentNumber}`} label={`${p.studentNumber}${p.major ? ` — ${p.major}` : ''}`} />
+          ))}
+        </section>
+      )}
+
+      {/* 이메일 */}
+      {(diff.emails.existing.length > 0 || diff.emails.toAdd.length > 0) && (
+        <section>
+          <h3 className="text-h3 mb-1">{d.sectionEmails}</h3>
+          {diff.emails.existing.map(e => (
+            <ExistingRow key={`${e.local}@${e.domain}`} label={`${e.local}@${e.domain}`} />
+          ))}
+          {diff.emails.toAdd.map(e => (
+            <AddRow key={`${e.local}@${e.domain}`} id={`em_${e.local}@${e.domain}`} label={`${e.local}@${e.domain}`} />
+          ))}
+        </section>
+      )}
+
+      {/* 그룹 */}
+      {diff.groups.items.length > 0 && (
+        <section>
+          <h3 className="text-h3 mb-1">{d.sectionGroups}</h3>
+          {diff.groups.items.filter(g => g.status === 'member').map(g => (
+            <ExistingRow key={g.groupIdx} label={`${groupName(g)} (${d.statusMember})`} />
+          ))}
+          {diff.groups.items.filter(g => g.status === 'pending').map(g => (
+            <AddRow
+              key={g.groupIdx}
+              id={`g_${g.groupIdx}`}
+              label={groupName(g)}
+              tag={`${d.statusPending} → ${groupReason(g)}`}
+            />
+          ))}
+          {diff.groups.items.filter(g => g.status === 'new').map(g => (
+            <AddRow
+              key={g.groupIdx}
+              id={`g_${g.groupIdx}`}
+              label={groupName(g)}
+              tag={groupReason(g)}
+            />
+          ))}
+        </section>
+      )}
+
+      {/* 적용 버튼 */}
+      {selectableItems.length > 0 ? (
+        <Button
+          color="primary"
+          disabled={applying || selected.size === 0}
+          onClick={handleApply}
+        >
+          {applying ? d.applying : d.buttonApply}
+        </Button>
+      ) : (
+        <p className="text-dimmed">{d.noChanges}</p>
+      )}
+    </div>
+  );
+}

--- a/app/[locale]/(authorized)/canvas/CanvasSync.tsx
+++ b/app/[locale]/(authorized)/canvas/CanvasSync.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { type ReactNode, useState } from 'react';
+import type { CanvasDiff } from '@/api/canvas';
+import { syncCanvas } from '@/api/canvas';
+import Button from '@/components/Button';
+import InputField from '@/components/InputField';
+import useLocaleDict from '@/components/LocaleDict';
+import { useToast } from '@/components/NotificationContext';
+import CanvasDiffView from './CanvasDiff';
+
+const CANVAS_URL = 'https://myetl.snu.ac.kr';
+
+function renderWithLink(text: string): ReactNode {
+  if (!text.includes('{link}')) return text;
+  const [before, after] = text.split('{link}');
+  return (
+    <>
+      {before}
+      <a href={CANVAS_URL} target="_blank" rel="noopener noreferrer" className="text-sky-600 hover:underline">
+        myetl.snu.ac.kr
+      </a>
+      {after}
+    </>
+  );
+}
+
+export default function CanvasSync() {
+  const { dict } = useLocaleDict();
+  const d = dict.canvas;
+  const showToast = useToast();
+
+  const [token, setToken] = useState('');
+  const [syncing, setSyncing] = useState(false);
+  const [diff, setDiff] = useState<CanvasDiff | null>(null);
+
+  async function handleSync() {
+    if (!token.trim()) return;
+    setSyncing(true);
+    setDiff(null);
+    try {
+      setDiff(await syncCanvas(token.trim()));
+    } catch (e) {
+      showToast({ type: 'error', message: e instanceof Error ? e.message : d.errorInvalidToken });
+    } finally {
+      setSyncing(false);
+    }
+  }
+
+  function handleApplied() {
+    setDiff(null);
+    setToken('');
+  }
+
+  return (
+    <div className="space-y-4">
+      <p>{renderWithLink(d.description)}</p>
+      <details>
+        <summary className="cursor-pointer text-sky-600 hover:underline text-sm">
+          {d.howToGetToken}
+        </summary>
+        <ol className="text-sm text-dimmed mt-1 list-decimal pl-4 space-y-1">
+          {d.howToGetTokenSteps.map((step: string, i: number) => (
+            <li key={i}>{renderWithLink(step)}</li>
+          ))}
+        </ol>
+      </details>
+      <div className="flex gap-2 items-end">
+        <div className="flex-1">
+          <InputField
+            label={d.tokenLabel}
+            type="password"
+            placeholder={d.tokenPlaceholder}
+            value={token}
+            onChange={e => setToken(e.target.value)}
+            labelClassName=""
+          />
+        </div>
+        <Button
+          color="primary"
+          disabled={syncing || !token.trim()}
+          onClick={handleSync}
+          className="flex-none"
+        >
+          {syncing ? d.syncing : d.buttonSync}
+        </Button>
+      </div>
+      {diff && <CanvasDiffView diff={diff} onApplied={handleApplied} />}
+    </div>
+  );
+}

--- a/app/[locale]/(authorized)/canvas/page.tsx
+++ b/app/[locale]/(authorized)/canvas/page.tsx
@@ -1,0 +1,14 @@
+import { getDictionary, Locale } from '@/locale';
+import CanvasSync from './CanvasSync';
+
+type Props = { params: { locale: Locale } };
+
+export default async function CanvasPage({ params: { locale } }: Props) {
+  const dict = await getDictionary(locale);
+  return (
+    <main className="p-4 max-w-2xl mx-auto">
+      <h1 className="text-h1 mb-4">{dict.canvas.title}</h1>
+      <CanvasSync />
+    </main>
+  );
+}

--- a/app/[locale]/(authorized)/group/GroupItem.tsx
+++ b/app/[locale]/(authorized)/group/GroupItem.tsx
@@ -144,7 +144,14 @@ export default function GroupItem(props: Props) {
   return (
     <div className="border rounded p-2">
       <div className="flex flex-row items-baseline justify-between">
-        <h3 className="text-h3">{group.name}</h3>
+        <div className="flex items-center gap-2">
+          <h3 className="text-h3">{group.name}</h3>
+          {(group.identifier === 'undergraduate' || group.identifier === 'graduate' || group.identifier.startsWith('course-')) && (
+            <span className="text-xs bg-blue-100 text-blue-700 rounded px-1 py-0.5">
+              {dict.canvas.canvasLinkedBadge}
+            </span>
+          )}
+        </div>
         {joinState}
       </div>
       <p className="text-dimmed">

--- a/app/[locale]/(authorized)/page.tsx
+++ b/app/[locale]/(authorized)/page.tsx
@@ -1,6 +1,8 @@
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
 import { checkSession } from '@/api';
+import Button from '@/components/Button';
 import { getDictionary, Locale } from '@/locale';
 
 import ChangePassword from './ChangePassword';
@@ -27,6 +29,17 @@ export default async function Home({
       <Groups dict={dict} />
       <ChangePassword dict={dict} />
       <StudentId dict={dict} />
+      <section className="border rounded p-2">
+        <h2 className="text-h2 mb-2">{dict.canvas.title}</h2>
+        <p className="text-dimmed">{dict.canvas.dashboardDescription}</p>
+        <div className="flex flex-col items-end mt-2">
+          <Link className="w-full max-w-32" href={`/${locale}/canvas`}>
+            <Button className="w-full font-bold" type="button" color="primary">
+              {dict.canvas.title}
+            </Button>
+          </Link>
+        </div>
+      </section>
     </section>
   );
 }

--- a/app/[locale]/signup/CanvasSignupFlow.tsx
+++ b/app/[locale]/signup/CanvasSignupFlow.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import { useParams, useRouter } from 'next/navigation';
+import { type ReactNode, useRef, useState } from 'react';
+
+import { previewCanvas, canvasSignup, type CanvasPreviewResult } from '@/api/canvas';
+import Button from '@/components/Button';
+import InputField from '@/components/InputField';
+import useLocaleDict from '@/components/LocaleDict';
+import { useToast } from '@/components/NotificationContext';
+
+const CANVAS_URL = 'https://myetl.snu.ac.kr';
+
+function renderWithLink(text: string): ReactNode {
+  if (!text.includes('{link}')) return text;
+  const [before, after] = text.split('{link}');
+  return (
+    <>
+      {before}
+      <a href={CANVAS_URL} target="_blank" rel="noopener noreferrer" className="text-sky-600 hover:underline">
+        myetl.snu.ac.kr
+      </a>
+      {after}
+    </>
+  );
+}
+
+export default function CanvasSignupFlow() {
+  const { dict } = useLocaleDict();
+  const d = dict.canvas;
+  const showToast = useToast();
+  const router = useRouter();
+  const params = useParams();
+  const locale = params.locale as string;
+
+  const [token, setToken] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [preview, setPreview] = useState<CanvasPreviewResult | null>(null);
+
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [passwordConfirm, setPasswordConfirm] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const passwordConfirmRef = useRef<HTMLInputElement>(null);
+
+  async function handlePreview() {
+    if (!token.trim()) return;
+    setLoading(true);
+    try {
+      setPreview(await previewCanvas(token.trim()));
+    } catch (e) {
+      showToast({ type: 'error', message: e instanceof Error ? e.message : d.errorInvalidToken });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleChangePassword(e: React.ChangeEvent<HTMLInputElement>) {
+    setPassword(e.target.value);
+    if (e.target.value !== passwordConfirm) {
+      passwordConfirmRef.current?.setCustomValidity(dict.validity.passwordConfirmMismatch);
+    } else {
+      passwordConfirmRef.current?.setCustomValidity('');
+    }
+  }
+
+  function handleChangePasswordConfirm(e: React.ChangeEvent<HTMLInputElement>) {
+    setPasswordConfirm(e.target.value);
+    if (password !== e.target.value) {
+      e.target.setCustomValidity(dict.validity.passwordConfirmMismatch);
+    } else {
+      e.target.setCustomValidity('');
+    }
+  }
+
+  async function handleSignup(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      await canvasSignup(token.trim(), username, password, locale);
+      router.push(`/${locale}/signup/done`);
+    } catch (e) {
+      showToast({ type: 'error', message: e instanceof Error ? e.message : dict.error.userCreationFailed });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  // Step 1: Token input
+  if (!preview) {
+    return (
+      <section className="border rounded p-2 space-y-3">
+        <p>{renderWithLink(d.description)}</p>
+        <details>
+          <summary className="cursor-pointer text-sky-600 hover:underline text-sm">
+            {d.howToGetToken}
+          </summary>
+          <ol className="text-sm text-dimmed mt-1 list-decimal pl-4 space-y-1">
+            {d.howToGetTokenSteps.map((step: string, i: number) => (
+              <li key={i}>{renderWithLink(step)}</li>
+            ))}
+          </ol>
+        </details>
+        <InputField
+          label={d.tokenLabel}
+          type="password"
+          placeholder={d.tokenPlaceholder}
+          value={token}
+          onChange={e => setToken(e.target.value)}
+        />
+        <Button
+          color="primary"
+          disabled={loading || !token.trim()}
+          onClick={handlePreview}
+          className="w-full"
+        >
+          {loading ? d.syncing : dict.signUp.form.signUpButton}
+        </Button>
+      </section>
+    );
+  }
+
+  // Step 2: Preview + signup form
+  const groupName = (g: CanvasPreviewResult['matchedGroups'][0]) =>
+    locale === 'ko' ? g.name.ko : g.name.en;
+
+  return (
+    <section className="border rounded p-2">
+      <form onSubmit={handleSignup} className="flex flex-col gap-3">
+        <div className="space-y-2 border rounded p-2">
+          <p className="text-sm font-bold">{d.signupPreview}</p>
+          <div className="text-sm">
+            <span className="text-dimmed">{d.signupPreviewName}:</span> {preview.name}
+          </div>
+          <div className="text-sm">
+            <span className="text-dimmed">{d.signupPreviewEmail}:</span> {preview.emails.join(', ') || '-'}
+          </div>
+          <div className="text-sm">
+            <span className="text-dimmed">{d.signupPreviewStudentNumbers}:</span>
+          </div>
+          {preview.profiles.length > 0 ? (
+            <ul className="text-sm list-disc pl-8">
+              {preview.profiles.map(p => (
+                <li key={p.studentNumber}>{p.studentNumber}{p.major && ` — ${p.major}`}</li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm pl-6 text-dimmed">-</p>
+          )}
+          {preview.matchedGroups.length > 0 ? (
+            <div className="text-sm">
+              <span className="text-dimmed">{d.signupPreviewGroups}:</span>
+              <ul className="list-disc pl-4 mt-1">
+                {preview.matchedGroups.map(g => {
+                  const name = groupName(g);
+                  const reason = g.reasonKey === 'student_id_cse'
+                    ? d.reasonStudentIdCse
+                    : g.reasonDetail
+                      ? d.reasonCourseWithTerm.replace('{}', g.reasonDetail)
+                      : d.reasonCourse;
+                  return (
+                    <li key={g.groupIdx}>
+                      {name} <span className="text-dimmed">({reason})</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          ) : (
+            <p className="text-sm text-dimmed">{d.signupNoGroups}</p>
+          )}
+        </div>
+
+        <hr />
+
+        <InputField
+          label={dict.signUp.form.fields.username}
+          required
+          pattern="[a-z][a-z0-9]*"
+          autoComplete="username"
+          value={username}
+          onChange={e => setUsername(e.target.value)}
+        />
+        <InputField
+          label={dict.signUp.form.fields.password}
+          type="password"
+          required
+          minLength={8}
+          autoComplete="new-password"
+          value={password}
+          onChange={handleChangePassword}
+        />
+        <InputField
+          ref={passwordConfirmRef}
+          label={dict.signUp.form.fields.passwordConfirm}
+          type="password"
+          required
+          minLength={8}
+          autoComplete="new-password"
+          value={passwordConfirm}
+          onChange={handleChangePasswordConfirm}
+        />
+        <Button
+          type="submit"
+          color="primary"
+          disabled={submitting}
+          className="w-full font-bold"
+        >
+          {dict.signUp.form.signUpButton}
+        </Button>
+      </form>
+    </section>
+  );
+}

--- a/app/[locale]/signup/EmailForm.tsx
+++ b/app/[locale]/signup/EmailForm.tsx
@@ -1,3 +1,4 @@
+/* === ARCHIVED: replaced by Canvas-based signup ===
 'use client';
 
 import { useRouter } from 'next/navigation';
@@ -91,3 +92,5 @@ export default function EmailForm() {
     </form>
   );
 }
+=== END ARCHIVED === */
+export default function ArchivedComponent() { return null; }

--- a/app/[locale]/signup/SignupForm.tsx
+++ b/app/[locale]/signup/SignupForm.tsx
@@ -1,3 +1,4 @@
+/* === ARCHIVED: replaced by Canvas-based signup ===
 'use client';
 
 import { useParams, useRouter } from 'next/navigation';
@@ -187,3 +188,5 @@ export default function SignupForm({ token, email }: Props) {
     </section>
   );
 }
+=== END ARCHIVED === */
+export default function ArchivedComponent() { return null; }

--- a/app/[locale]/signup/page.tsx
+++ b/app/[locale]/signup/page.tsx
@@ -1,4 +1,10 @@
 import { Metadata } from 'next';
+
+import { getDictionary, Locale } from '@/locale';
+import CanvasSignupFlow from './CanvasSignupFlow';
+
+/* === ARCHIVED: email-based signup ===
+import { Metadata } from 'next';
 import Link from 'next/link';
 import { Suspense } from 'react';
 
@@ -76,4 +82,30 @@ async function SignupFormWrapper(
   }
 
   return <SignupForm token={props.token} email={email} />;
+}
+=== END ARCHIVED === */
+
+type Props = {
+  params: { locale: Locale };
+};
+
+export async function generateMetadata({
+  params: { locale },
+}: Props): Promise<Metadata> {
+  const dict = await getDictionary(locale);
+  return {
+    title: dict.title.signUp,
+  };
+}
+
+export default async function Signup({
+  params: { locale },
+}: Props) {
+  const dict = await getDictionary(locale);
+  return (
+    <section className="border rounded p-2">
+      <h2 className="text-h2 mb-2">{dict.title.signUp}</h2>
+      <CanvasSignupFlow />
+    </section>
+  );
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -6,7 +6,7 @@
     "changePassword": "Change password",
     "groups": "Manage groups",
     "consent": "Authorization Request",
-    "studentId": "Add Student ID"
+    "studentId": "Student IDs"
   },
   "welcome": "Welcome, {}.",
   "signIn": {
@@ -135,16 +135,56 @@
     "passwordConfirmMismatch": "Passwords do not match."
   },
   "studentId": {
-    "description": "Add a new student ID to your profile. Use this when you receive a new student ID, such as when transitioning from undergraduate to graduate studies.",
+    "description": "Your student IDs. New student IDs can be added via Canvas integration.",
     "contactNote": "If you mistakenly added the wrong student ID, contact us at {email}.",
     "currentStudentId": "Current Student ID: ",
     "add": "Add",
     "studentNumberConfirm": "Confirm",
     "buttonAdd": "Add",
+    "buttonDelete": "Delete",
     "successMessage": "Student ID has been added.",
     "errorDuplicate": "This student ID is already registered.",
     "errorMismatch": "Student IDs do not match.",
     "errorInvalidFormat": "Invalid student ID format."
+  },
+  "canvas": {
+    "title": "Canvas Integration",
+    "description": "Enter your Canvas ({link}) Access Token to sync your student IDs, emails, and course enrollments.",
+    "howToGetToken": "How to get a token",
+    "howToGetTokenSteps": [
+      "Log in to Canvas ({link})",
+      "Left menu 'Account' → 'Settings'",
+      "'Approved Integrations' section",
+      "Click '+ New Access Token' to generate"
+    ],
+    "tokenLabel": "Canvas Access Token",
+    "tokenPlaceholder": "Enter Access Token",
+    "buttonSync": "Check Sync",
+    "buttonApply": "Apply Selected",
+    "syncing": "Fetching data from Canvas...",
+    "applying": "Applying changes...",
+    "noChanges": "Your account is already in sync with Canvas.",
+    "applySuccess": "Changes applied successfully.",
+    "errorInvalidToken": "Invalid token. Please generate a new one from Canvas.",
+    "sectionStudentNumbers": "Student Numbers",
+    "sectionEmails": "Emails",
+    "sectionGroups": "Groups",
+    "actionAdd": "Add",
+    "statusMember": "Joined",
+    "statusPending": "Pending approval",
+    "canvasLinkedBadge": "Canvas Linked",
+    "reasonStudentIdCse": "Student ID & CSE major detected",
+    "signupPreviewMajors": "Major",
+    "reasonCourse": "Course enrollment",
+    "reasonCourseWithTerm": "{} course enrollment",
+    "signupPreview": "Canvas verification complete",
+    "signupPreviewName": "Name",
+    "signupPreviewEmail": "Email",
+    "signupPreviewStudentNumbers": "Student Numbers",
+    "signupPreviewGroups": "Auto-join groups",
+    "signupNoGroups": "No matching auto-join groups.",
+    "dashboardDescription": "Sync your student IDs, emails, and groups via Canvas Access Token.",
+    "dashboardButton": "Connect Canvas"
   },
   "error": {
     "signIn": "Signing in failed.",

--- a/locale/ko.json
+++ b/locale/ko.json
@@ -6,7 +6,7 @@
     "changePassword": "비밀번호 변경",
     "groups": "그룹 관리",
     "consent": "권한 요청",
-    "studentId": "학번 추가"
+    "studentId": "학번 관리"
   },
   "welcome": "{}님, 환영합니다.",
   "signIn": {
@@ -135,16 +135,56 @@
     "passwordConfirmMismatch": "두 비밀번호가 일치하지 않습니다."
   },
   "studentId": {
-    "description": "새 학번을 추가합니다. 학부생에서 대학원생이 되어 새 학번을 받은 경우 등에 사용합니다.",
+    "description": "학번 목록입니다. 학번 추가는 Canvas 연동을 통해 이루어집니다.",
     "contactNote": "잘못된 학번을 추가한 경우, {email}로 문의해 주세요.",
     "currentStudentId": "현재 학번: ",
     "add": "추가",
     "studentNumberConfirm": "확인",
     "buttonAdd": "추가",
+    "buttonDelete": "삭제",
     "successMessage": "학번이 추가되었습니다.",
     "errorDuplicate": "이미 등록된 학번입니다.",
     "errorMismatch": "두 학번이 일치하지 않습니다.",
     "errorInvalidFormat": "잘못된 학번 형식입니다."
+  },
+  "canvas": {
+    "title": "Canvas 연동",
+    "description": "Canvas({link})의 Access Token을 입력하면 학번, 이메일, 수업 정보를 기반으로 계정 정보를 동기화합니다.",
+    "howToGetToken": "토큰 발급 방법",
+    "howToGetTokenSteps": [
+      "Canvas({link})에 로그인",
+      "좌측 메뉴 '계정' → '설정'",
+      "'승인된 연동' 또는 'Approved Integrations' 섹션",
+      "'+ 새 액세스 토큰' 클릭하여 발급"
+    ],
+    "tokenLabel": "Canvas Access Token",
+    "tokenPlaceholder": "Access Token 입력",
+    "buttonSync": "동기화 확인",
+    "buttonApply": "선택 항목 적용",
+    "syncing": "Canvas에서 정보를 불러오는 중...",
+    "applying": "변경 사항 적용 중...",
+    "noChanges": "Canvas 정보와 현재 계정 정보가 동일합니다.",
+    "applySuccess": "변경 사항이 적용되었습니다.",
+    "errorInvalidToken": "토큰이 유효하지 않습니다. Canvas에서 새 토큰을 발급해 주세요.",
+    "sectionStudentNumbers": "학번",
+    "sectionEmails": "이메일",
+    "sectionGroups": "그룹",
+    "actionAdd": "추가",
+    "statusMember": "가입됨",
+    "statusPending": "승인 대기 중",
+    "canvasLinkedBadge": "Canvas 연동",
+    "reasonStudentIdCse": "학번 및 주전공 컴퓨터공학부 감지",
+    "signupPreviewMajors": "주전공",
+    "reasonCourse": "과목 등록",
+    "reasonCourseWithTerm": "{} 과목 등록",
+    "signupPreview": "Canvas 인증 완료",
+    "signupPreviewName": "이름",
+    "signupPreviewEmail": "이메일",
+    "signupPreviewStudentNumbers": "학번",
+    "signupPreviewGroups": "자동 가입 그룹",
+    "signupNoGroups": "해당하는 자동 가입 그룹이 없습니다.",
+    "dashboardDescription": "Canvas Access Token으로 학번, 이메일, 그룹을 동기화합니다.",
+    "dashboardButton": "Canvas 연동하기"
   },
   "error": {
     "signIn": "로그인에 실패했습니다.",

--- a/middleware.ts
+++ b/middleware.ts
@@ -29,7 +29,7 @@ export function middleware(request: NextRequest) {
   let resp;
   let matchingLocale;
   if (
-    ['/signup/email', '/signup/create', '/password/email', '/password/change', '/user/student-numbers'].includes(pathname) ||
+    ['/signup/email', '/signup/create', '/signup/canvas', '/password/email', '/password/change', '/user/student-numbers', '/user/email', '/canvas/preview', '/canvas/sync', '/canvas/apply'].includes(pathname) ||
     /^\/group\/[^\/]+\/membership$/.test(pathname) ||
     /^\/session\/[^\/]+$/.test(pathname) ||
     /^\/oauth\/[^\/]+$/.test(pathname)


### PR DESCRIPTION
- Canvas token signup flow with profile preview
- Sync page with add-only diff (3-state groups: member/pending/new)
- Dashboard canvas section, group canvas badge, student ID delete UI
- i18n support (ko/en) for all canvas strings
- Archive old EmailForm/SignupForm (preserved, not deleted)