### PR TITLE
feat: add conflict handling, identity verification UI, and i18n fixes

### DIFF
--- a/api/canvas.ts
+++ b/api/canvas.ts
@@ -3,6 +3,11 @@ export type CanvasProfilePair = {
   major: string;
 };
 
+export type CanvasConflicts = {
+  emails: string[];
+  studentNumbers: string[];
+};
+
 export type CanvasPreviewResult = {
   name: string;
   emails: string[];
@@ -13,6 +18,7 @@ export type CanvasPreviewResult = {
     reasonKey: 'student_id_cse' | 'course';
     reasonDetail?: string;
   }>;
+  conflicts: CanvasConflicts | null;
 };
 
 export type CanvasDiff = {
@@ -34,7 +40,6 @@ export type CanvasDiff = {
 
 export type CanvasAction =
   | { type: 'add_student_number'; studentNumber: string }
-  | { type: 'add_email'; emailLocal: string; emailDomain: string }
   | { type: 'add_group'; groupIdx: number };
 
 export async function previewCanvas(canvasToken: string): Promise<CanvasPreviewResult> {

--- a/app/[locale]/(authorized)/canvas/CanvasDiff.tsx
+++ b/app/[locale]/(authorized)/canvas/CanvasDiff.tsx
@@ -21,7 +21,6 @@ export default function CanvasDiffView({ diff, onApplied }: Props) {
 
   const selectableItems = [
     ...(diff.profiles?.toAdd ?? []).map(p => `sn_${p.studentNumber}`),
-    ...diff.emails.toAdd.map(e => `em_${e.local}@${e.domain}`),
     ...diff.groups.items.filter(g => g.status === 'new' || g.status === 'pending').map(g => `g_${g.groupIdx}`),
   ];
 
@@ -40,9 +39,6 @@ export default function CanvasDiffView({ diff, onApplied }: Props) {
     const actions: CanvasAction[] = [];
     (diff.profiles?.toAdd ?? []).forEach(p => {
       if (selected.has(`sn_${p.studentNumber}`)) actions.push({ type: 'add_student_number', studentNumber: p.studentNumber });
-    });
-    diff.emails.toAdd.forEach(e => {
-      if (selected.has(`em_${e.local}@${e.domain}`)) actions.push({ type: 'add_email', emailLocal: e.local, emailDomain: e.domain });
     });
     diff.groups.items.filter(g => g.status === 'new' || g.status === 'pending').forEach(g => {
       if (selected.has(`g_${g.groupIdx}`)) actions.push({ type: 'add_group', groupIdx: g.groupIdx });
@@ -105,19 +101,6 @@ export default function CanvasDiffView({ diff, onApplied }: Props) {
           ))}
           {(diff.profiles?.toAdd ?? []).map(p => (
             <AddRow key={p.studentNumber} id={`sn_${p.studentNumber}`} label={`${p.studentNumber}${p.major ? ` — ${p.major}` : ''}`} />
-          ))}
-        </section>
-      )}
-
-      {/* 이메일 */}
-      {(diff.emails.existing.length > 0 || diff.emails.toAdd.length > 0) && (
-        <section>
-          <h3 className="text-h3 mb-1">{d.sectionEmails}</h3>
-          {diff.emails.existing.map(e => (
-            <ExistingRow key={`${e.local}@${e.domain}`} label={`${e.local}@${e.domain}`} />
-          ))}
-          {diff.emails.toAdd.map(e => (
-            <AddRow key={`${e.local}@${e.domain}`} id={`em_${e.local}@${e.domain}`} label={`${e.local}@${e.domain}`} />
           ))}
         </section>
       )}

--- a/app/[locale]/(authorized)/page.tsx
+++ b/app/[locale]/(authorized)/page.tsx
@@ -31,7 +31,7 @@ export default async function Home({
       <StudentId dict={dict} />
       <section className="border rounded p-2">
         <h2 className="text-h2 mb-2">{dict.canvas.title}</h2>
-        <p className="text-dimmed">{dict.canvas.dashboardDescription}</p>
+        <p>{dict.canvas.dashboardDescription}</p>
         <div className="flex flex-col items-end mt-2">
           <Link className="w-full max-w-32" href={`/${locale}/canvas`}>
             <Button className="w-full font-bold" type="button" color="primary">

--- a/app/[locale]/signup/CanvasSignupFlow.tsx
+++ b/app/[locale]/signup/CanvasSignupFlow.tsx
@@ -171,43 +171,58 @@ export default function CanvasSignupFlow() {
           )}
         </div>
 
-        <hr />
+        {preview.conflicts ? (
+          <div className="border border-red-400 rounded p-2 space-y-1">
+            <p className="text-sm font-bold text-red-500">{d.conflictTitle}</p>
+            {preview.conflicts.emails.length > 0 && (
+              <p className="text-sm">{d.conflictEmail}: {preview.conflicts.emails.join(', ')}</p>
+            )}
+            {preview.conflicts.studentNumbers.length > 0 && (
+              <p className="text-sm">{d.conflictStudentNumber}: {preview.conflicts.studentNumbers.join(', ')}</p>
+            )}
+            <p className="text-sm text-dimmed">{d.conflictDescription}</p>
+          </div>
+        ) : (
+          <>
+            <hr />
 
-        <InputField
-          label={dict.signUp.form.fields.username}
-          required
-          pattern="[a-z][a-z0-9]*"
-          autoComplete="username"
-          value={username}
-          onChange={e => setUsername(e.target.value)}
-        />
-        <InputField
-          label={dict.signUp.form.fields.password}
-          type="password"
-          required
-          minLength={8}
-          autoComplete="new-password"
-          value={password}
-          onChange={handleChangePassword}
-        />
-        <InputField
-          ref={passwordConfirmRef}
-          label={dict.signUp.form.fields.passwordConfirm}
-          type="password"
-          required
-          minLength={8}
-          autoComplete="new-password"
-          value={passwordConfirm}
-          onChange={handleChangePasswordConfirm}
-        />
-        <Button
-          type="submit"
-          color="primary"
-          disabled={submitting}
-          className="w-full font-bold"
-        >
-          {dict.signUp.form.signUpButton}
-        </Button>
+            <InputField
+              label={dict.signUp.form.fields.username}
+              required
+              pattern="[a-z][a-z0-9]*"
+              autoComplete="username"
+              value={username}
+              onChange={e => setUsername(e.target.value)}
+            />
+            <InputField
+              label={dict.signUp.form.fields.password}
+              type="password"
+              required
+              minLength={8}
+              autoComplete="new-password"
+              value={password}
+              onChange={handleChangePassword}
+            />
+            <InputField
+              ref={passwordConfirmRef}
+              label={dict.signUp.form.fields.passwordConfirm}
+              type="password"
+              required
+              minLength={8}
+              autoComplete="new-password"
+              value={passwordConfirm}
+              onChange={handleChangePasswordConfirm}
+            />
+            <Button
+              type="submit"
+              color="primary"
+              disabled={submitting}
+              className="w-full font-bold"
+            >
+              {dict.signUp.form.signUpButton}
+            </Button>
+          </>
+        )}
       </form>
     </section>
   );

--- a/locale/en.json
+++ b/locale/en.json
@@ -149,7 +149,7 @@
   },
   "canvas": {
     "title": "Canvas Integration",
-    "description": "Enter your Canvas ({link}) Access Token to sync your student IDs, emails, and course enrollments.",
+    "description": "Enter your Canvas ({link}) Access Token to verify your email and sync your student IDs and course enrollments.",
     "howToGetToken": "How to get a token",
     "howToGetTokenSteps": [
       "Log in to Canvas ({link})",
@@ -172,7 +172,7 @@
     "actionAdd": "Add",
     "statusMember": "Joined",
     "statusPending": "Pending approval",
-    "canvasLinkedBadge": "Canvas Linked",
+    "canvasLinkedBadge": "Also joinable via Canvas token",
     "reasonStudentIdCse": "Student ID & CSE major detected",
     "signupPreviewMajors": "Major",
     "reasonCourse": "Course enrollment",
@@ -183,7 +183,12 @@
     "signupPreviewStudentNumbers": "Student Numbers",
     "signupPreviewGroups": "Auto-join groups",
     "signupNoGroups": "No matching auto-join groups.",
-    "dashboardDescription": "Sync your student IDs, emails, and groups via Canvas Access Token.",
+    "conflictTitle": "Cannot create account",
+    "conflictEmail": "Email already registered",
+    "conflictStudentNumber": "Student number already registered",
+    "conflictDescription": "The information above is already registered to another account. Please sign in with your existing account or contact an administrator.",
+    "syncIdentityMismatch": "Canvas account name or email does not match your current account.",
+    "dashboardDescription": "Sync your student IDs and groups via Canvas Access Token.",
     "dashboardButton": "Connect Canvas"
   },
   "error": {

--- a/locale/ko.json
+++ b/locale/ko.json
@@ -149,7 +149,7 @@
   },
   "canvas": {
     "title": "Canvas 연동",
-    "description": "Canvas({link})의 Access Token을 입력하면 학번, 이메일, 수업 정보를 기반으로 계정 정보를 동기화합니다.",
+    "description": "Canvas({link})의 Access Token을 입력하면 이메일 일치 여부를 검증한 후 학번, 수업 정보를 기반으로 계정 정보를 동기화합니다.",
     "howToGetToken": "토큰 발급 방법",
     "howToGetTokenSteps": [
       "Canvas({link})에 로그인",
@@ -172,7 +172,7 @@
     "actionAdd": "추가",
     "statusMember": "가입됨",
     "statusPending": "승인 대기 중",
-    "canvasLinkedBadge": "Canvas 연동",
+    "canvasLinkedBadge": "Canvas 토큰으로도 가입 가능",
     "reasonStudentIdCse": "학번 및 주전공 컴퓨터공학부 감지",
     "signupPreviewMajors": "주전공",
     "reasonCourse": "과목 등록",
@@ -183,7 +183,12 @@
     "signupPreviewStudentNumbers": "학번",
     "signupPreviewGroups": "자동 가입 그룹",
     "signupNoGroups": "해당하는 자동 가입 그룹이 없습니다.",
-    "dashboardDescription": "Canvas Access Token으로 학번, 이메일, 그룹을 동기화합니다.",
+    "conflictTitle": "계정을 생성할 수 없습니다",
+    "conflictEmail": "이미 등록된 이메일",
+    "conflictStudentNumber": "이미 등록된 학번",
+    "conflictDescription": "위 정보가 이미 다른 계정에 등록되어 있습니다. 기존 계정으로 로그인하거나 관리자에게 문의하세요.",
+    "syncIdentityMismatch": "Canvas 계정의 이름 또는 이메일이 현재 계정과 일치하지 않습니다.",
+    "dashboardDescription": "Canvas Access Token으로 학번, 그룹을 동기화합니다.",
     "dashboardButton": "Canvas 연동하기"
   },
   "error": {


### PR DESCRIPTION
- Signup: show conflict details when email/student number already registered
- Signup: hide username/password form when conflicts exist
- Sync: remove email section (email is identity, not syncable)
- Update descriptions to reflect email verification before sync
- Remove text-dimmed from dashboard canvas description
- Change canvas badge to "Canvas 토큰으로도 가입 가능"